### PR TITLE
Fix missing ovos-backend-client library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ovos-backend-client
 ovos-bus-client~=0.0, >=0.0.3a10
 ovos-utils~=0.0, >=0.0.31a5
 ovos-config~=0.0,>=0.0.8a3


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ovos/.venv/bin/ovos-gui-service", line 33, in <module>
    sys.exit(load_entry_point('ovos-gui==0.0.2a10', 'console_scripts', 'ovos-gui-service')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/bin/ovos-gui-service", line 25, in importlib_load_entry_point
    return next(matches).load()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_gui/__main__.py", line 6, in <module>
    from ovos_gui.service import GUIService
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_gui/service.py", line 5, in <module>
    from ovos_gui.extensions import ExtensionsManager
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_gui/extensions.py", line 4, in <module>
    from ovos_backend_client.pairing import is_paired
ModuleNotFoundError: No module named 'ovos_backend_client'
```