### PR TITLE
refactor/remove_dashboard

### DIFF
--- a/ovos_gui/interfaces/smartspeaker.py
+++ b/ovos_gui/interfaces/smartspeaker.py
@@ -34,8 +34,6 @@ class SmartSpeakerExtensionGuiInterface(GUIInterface):
         super().set_bus(self.bus)
 
         self.bus.on("mycroft.device.settings", self.handle_device_settings)
-        self.bus.on("ovos.PHAL.dashboard.status.response",
-                    self.update_device_dashboard_status)
 
         self.bus.on("ovos.phal.configuration.provider.get.response",
                     self.display_advanced_config_for_group)
@@ -52,10 +50,6 @@ class SmartSpeakerExtensionGuiInterface(GUIInterface):
                               self.handle_device_ssh_settings)
         self.register_handler(
             "mycroft.device.settings.developer", self.handle_device_developer_settings)
-        self.register_handler("mycroft.device.enable.dash",
-                              self.handle_device_developer_enable_dash)
-        self.register_handler("mycroft.device.disable.dash",
-                              self.handle_device_developer_disable_dash)
         self.register_handler("mycroft.device.show.idle",
                               self.handle_show_homescreen)
         self.register_handler("mycroft.device.settings.customize",
@@ -114,29 +108,6 @@ class SmartSpeakerExtensionGuiInterface(GUIInterface):
 
     def handle_device_developer_settings(self, message):
         self['state'] = 'settings/developer_settings'
-        self.handle_get_dash_status()
-
-    def handle_device_developer_enable_dash(self, message):
-        self.bus.emit(Message("ovos.PHAL.dashboard.enable"))
-
-    def handle_device_developer_disable_dash(self, message):
-        self.bus.emit(Message("ovos.PHAL.dashboard.disable"))
-
-    def update_device_dashboard_status(self, message):
-        call_check = message.data.get("status", False)
-        dash_security_pass = message.data.get("password", "")
-        dash_security_user = message.data.get("username", "")
-        dash_url = message.data.get("url", "")
-        if call_check:
-            self["dashboard_enabled"] = call_check
-            self["dashboard_url"] = dash_url
-            self["dashboard_user"] = dash_security_user
-            self["dashboard_password"] = dash_security_pass
-        else:
-            self["dashboard_enabled"] = call_check
-            self["dashboard_url"] = ""
-            self["dashboard_user"] = ""
-            self["dashboard_password"] = ""
 
     def handle_device_customize_settings(self, message):
         self['state'] = 'settings/customize_settings'
@@ -209,9 +180,6 @@ class SmartSpeakerExtensionGuiInterface(GUIInterface):
         self["groupList"] = groups_list
         self['state'] = 'settings/configuration_groups_display'
         self.show_page("SYSTEM_AdditionalSettings.qml", override_idle=True)
-
-    def handle_get_dash_status(self):
-        self.bus.emit(Message("ovos.PHAL.dashboard.get.status"))
 
     def build_initial_about_page_data(self):
         uname_info = platform.uname()

--- a/ovos_gui/res/ui/settings/developer_settings.qml
+++ b/ovos_gui/res/ui/settings/developer_settings.qml
@@ -25,12 +25,7 @@ import QtGraphicalEffects 1.12
 Item {
     id: developerSettingsView
     anchors.fill: parent
-    property bool dashActive: sessionData.dashboard_enabled ? Boolean(sessionData.dashboard_enabled) : false
     property bool busyVisible: false
-
-    onDashActiveChanged: {
-        developerSettingsView.busyVisible = false
-    }
 
     Item {
         id: topArea
@@ -66,101 +61,6 @@ Item {
             anchors.centerIn: parent
             running: viewBusyOverlay.visible
             enabled: viewBusyOverlay.visible
-        }
-    }
-
-    Flickable {
-        anchors.top: topArea.bottom
-        anchors.topMargin: Kirigami.Units.largeSpacing
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: midBottomArea.top
-        contentWidth: width
-        contentHeight: colMiddleContents.implicitHeight
-        clip: true
-
-        ColumnLayout {
-            id: colMiddleContents
-            anchors.left: parent.left
-            anchors.right: parent.right
-            spacing: Kirigami.Units.smallSpacing
-
-            Kirigami.Heading {
-                id: warnText
-                level: 3
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                color: Kirigami.Theme.textColor
-                text: "Enabling OVOS Dashboard will provide you access to control various services on this device, the OVOS Dashboard can be accessed on any device located in your LAN network"
-            }
-
-            Item {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Kirigami.Units.largeSpacing
-            }
-
-            Button {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Kirigami.Units.gridUnit * 3
-                text: "Enable Dashboard"
-                visible: !dashActive
-                enabled: visible
-                onClicked: {
-                    Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("../../snd/clicked.wav"))
-                    triggerGuiEvent("mycroft.device.enable.dash", {})
-                    developerSettingsView.busyVisible = true
-                }
-            }
-
-            Button {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Kirigami.Units.gridUnit * 3
-                text: "Disable Dashboard"
-                visible: dashActive
-                enabled: visible
-                onClicked: {
-                    Mycroft.SoundEffects.playClickedSound(Qt.resolvedUrl("../../snd/clicked.wav"))
-                    triggerGuiEvent("mycroft.device.disable.dash", {})
-                    developerSettingsView.busyVisible = true
-                }
-            }
-
-            Kirigami.Separator {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                visible: dashActive
-                enabled: visible
-            }
-
-            Kirigami.Heading {
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                level: 3
-                color: Kirigami.Theme.textColor
-                text: "Dashboard Address: " +  sessionData.dashboard_url
-                visible: dashActive
-                enabled: visible
-            }
-
-            Kirigami.Heading {
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                level: 3
-                color: Kirigami.Theme.textColor
-                text: "Dashboard Username: " + sessionData.dashboard_user
-                visible: dashActive
-                enabled: visible
-            }
-
-            Kirigami.Heading {
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                level: 3
-                color: Kirigami.Theme.textColor
-                text: "Dashboard Password: " + sessionData.dashboard_password
-                visible: dashActive
-                enabled: visible
-            }
         }
     }
 

--- a/ovos_gui/res/ui/translations/developer_settings_de.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_de.ts
@@ -14,31 +14,6 @@
         <translation>Erweiterte Einstellungen</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Dashboard aktivieren</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Dashboard deaktivieren</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Dashboard Adresse</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Dashboard Benutzername</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Dashboard Passwort</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Geräteeinstellungen</translation>

--- a/ovos_gui/res/ui/translations/developer_settings_es.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_es.ts
@@ -14,31 +14,6 @@
         <translation>Ajustes avanzados</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Habilitar panel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Deshabilitar panel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Dirección del tablero</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Nombre de usuario del panel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Contraseña del panel</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Configuración de dispositivo</translation>

--- a/ovos_gui/res/ui/translations/developer_settings_fr.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_fr.ts
@@ -14,31 +14,6 @@
         <translation>Réglages avancés</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Activer le tableau de bord</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Désactiver le tableau de bord</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Adresse du tableau de bord</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Nom d&apos;utilisateur du tableau de bord</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Mot de passe du tableau de bord</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Réglages de l&apos;appareil</translation>

--- a/ovos_gui/res/ui/translations/developer_settings_it.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_it.ts
@@ -14,31 +14,6 @@
         <translation>Impostazioni avanzate</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Abilita dashboard</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Disabilita dashboard</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Indirizzo dashboard</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Nome utente dashboard</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Password dashboard</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Impostazioni dispositivo</translation>

--- a/ovos_gui/res/ui/translations/developer_settings_nl.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_nl.ts
@@ -14,31 +14,6 @@
         <translation>Geavanceerde instellingen</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Dashboard inschakelen</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Dashboard uitschakelen</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Dashboardadres</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Dashboard-gebruikersnaam</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Dashboardwachtwoord</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Apparaat instellingen</translation>

--- a/ovos_gui/res/ui/translations/developer_settings_pt.ts
+++ b/ovos_gui/res/ui/translations/developer_settings_pt.ts
@@ -14,31 +14,6 @@
         <translation>Configurações avançadas</translation>
     </message>
     <message>
-        <location filename="developer_settings.qml" line="152"/>
-        <source>Enable Dashboard</source>
-        <translation>Ativar painel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="165"/>
-        <source>Disable Dashboard</source>
-        <translation>Desativar painel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="187"/>
-        <source>Dashboard Address</source>
-        <translation>Endereço do painel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="197"/>
-        <source>Dashboard Username</source>
-        <translation>Nome de usuário do painel</translation>
-    </message>
-    <message>
-        <location filename="developer_settings.qml" line="207"/>
-        <source>Dashboard Password</source>
-        <translation>Senha do painel</translation>
-    </message>
-    <message>
         <location filename="developer_settings.qml" line="250"/>
         <source>Device Settings</source>
         <translation>Configurações do dispositivo</translation>

--- a/protocol.md
+++ b/protocol.md
@@ -19,7 +19,9 @@ This protocol defines how ovos-gui communicates with connected clients
   * [Remove items from the list](#remove-items-from-the-list-1)
 
 
-# CONNECTION
+# OVOS Protocol Extensions
+
+## CONNECTION
 
 on connection gui clients announce themselves
 
@@ -32,8 +34,31 @@ This is an extension by OVOS to the original mycroft protocol
     "gui_id": "unique_identifier_provided_by_client"
 }
 ```
+## SPECIAL EVENT: page_gained_focus
+```javascript
+{
+    "type": "mycroft.events.triggered",
+    "namespace": "mycroft.weather",
+    "event_name": "page_gained_focus",
+    "data": {"number": 0}
+}
+```
+## UPLOAD PAGE
 
-# ACTIVE SKILLS LIST
+skills can upload qml contents directly via messagebus
+
+
+```javascript
+{
+    "type": "mycroft.gui.connected",
+    "gui_id": "unique_identifier_provided_by_client"
+}
+```
+
+
+# Original Protocol
+
+## ACTIVE SKILLS LIST
 
 The active skill data, described in the section MODELS is mandatory for the rest of the protocol to work. I.e. if some data or an event arrives with namespace "mycroft.weather", the skill id "mycroft.weather" must have been advertised as recently used in the recent skills model beforehand, otherwise all requests on that namespace will be ignored on both client and serverside and considered a protocol error.
 Recent skills are ordered from the last used to the oldest, so the first item of the model will always be the the one showing any QML GUI, if available.


### PR DESCRIPTION
remove dashboard UI from ovos-shell integration

it will no longer show in the dropdown menu, it can be restored once gui extensions are made into plugins for some dedicated GUI extension that wants it

the dashboard plugin itself will still work, only the hardcoded dropdown UI integration has been removed