### PR TITLE
fix:handle unloaded namespaces

### DIFF
--- a/ovos_gui/namespace.py
+++ b/ovos_gui/namespace.py
@@ -778,6 +778,10 @@ class NamespaceManager:
         @param pages_to_show: list of pages to be loaded
         @param show_index: index to load pages at
         """
+        if not self.active_namespaces:
+            LOG.error("received 'load_pages' request but there are no active namespaces")
+            return
+
         if not len(pages_to_show) or show_index >= len(pages_to_show):
             LOG.error(f"requested invalid page index: {show_index}, defaulting to last page")
             show_index = len(pages_to_show) - 1
@@ -1011,6 +1015,10 @@ class NamespaceManager:
         Handles global back events from the GUI.
         @param message: the event sent by the GUI
         """
+        if not self.active_namespaces:
+            LOG.error("received 'back' signal but there are no active namespaces")
+            return
+
         namespace_name = self.active_namespaces[0].skill_id
         namespace = self.loaded_namespaces.get(namespace_name)
         if namespace in self.active_namespaces:


### PR DESCRIPTION
happens every boot
```
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]: 2024-09-18 19:45:11.325 - gui - ovos_gui_plugin_shell_companion:handle_remove_namespace:84 - INFO - Got Clear Namespace Event In Skill
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]: [E 240918 19:45:11 _base:342] exception calling callback for <Future at 0xffff8463a250 state=finished raised IndexError>
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:     Traceback (most recent call last):
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/usr/lib/python3.11/concurrent/futures/_base.py", line 340, in _invoke_callbacks
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         callback(self)
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_executor.py", line 57, in _callback
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         self.emit("error", exc)
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_base.py", line 118, in emit
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         self._emit_handle_potential_error(event, args[0] if args else None)
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/home/ovos/.venv/lib/python3.11/site-packages/pyee/_base.py", line 88, in _emit_handle_potential_error
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         raise error
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         result = self.fn(*self.args, **self.kwargs)
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:       File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_gui/namespace.py", line 1014, in handle_namespace_global_back
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:         namespace_name = self.active_namespaces[0].skill_id
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:                          ~~~~~~~~~~~~~~~~~~~~~~^^^
Sep 18 19:45:11 OpenVoiceOS ovos-gui-websocket[793]:     IndexError: list index out of range
```