### PR TITLE
fix:no wait for ready

### DIFF
--- a/ovos_gui/homescreen.py
+++ b/ovos_gui/homescreen.py
@@ -13,7 +13,6 @@ class HomescreenManager(Thread):
         super().__init__()
         self.bus = bus
         self.homescreens: List[dict] = []
-        self.mycroft_ready = False
 
         self.bus.on('homescreen.manager.add', self.add_homescreen)
         self.bus.on('homescreen.manager.remove', self.remove_homescreen)
@@ -22,13 +21,13 @@ class HomescreenManager(Thread):
         self.bus.on("homescreen.manager.set_active", self.handle_set_active_homescreen)
         self.bus.on("homescreen.manager.disable_active", self.disable_active_homescreen)
         self.bus.on("homescreen.manager.show_active", self.show_homescreen)
-        self.bus.on("mycroft.ready", self.set_mycroft_ready)
 
     def run(self):
         """
         Start the Manager after it has been constructed.
         """
         self.reload_homescreens_list()
+        self.show_homescreen()
 
     def add_homescreen(self, message: Message):
         """
@@ -127,9 +126,6 @@ class HomescreenManager(Thread):
         Check if a homescreen should be displayed immediately upon addition
         @param homescreen_id: ID of added homescreen
         """
-        if not self.mycroft_ready:
-            LOG.debug("Not ready yet, don't display homescreen")
-            return
         LOG.debug(f"Checking {homescreen_id}")
         if self.get_active_homescreen() != homescreen_id:
             # Added homescreen isn't the configured one, do nothing
@@ -172,12 +168,3 @@ class HomescreenManager(Thread):
         else:
             LOG.warning(f"Requested {active_homescreen} not found in: "
                         f"{self.homescreens}")
-
-    def set_mycroft_ready(self, message: Message):
-        """
-        Handle `mycroft.ready` and show the homescreen
-        @param message: `mycroft.ready` Message
-        """
-        self.mycroft_ready = True
-        self.reload_homescreens_list()
-        self.show_homescreen()

--- a/ovos_gui/service.py
+++ b/ovos_gui/service.py
@@ -63,16 +63,6 @@ class GUIService:
 
         self.extension_manager = ExtensionsManager("EXTENSION_SERVICE", self.bus)
         self.namespace_manager = NamespaceManager(self.bus)
-
-        # Bus is connected, check if the skills service is ready
-        resp = self.bus.wait_for_response(
-            Message("mycroft.skills.is_ready",
-                    context={"source": "gui", "destination": ["skills"]}))
-        if resp and resp.data.get("status"):
-            LOG.debug("Skills service already running")
-            self.namespace_manager.handle_ready(resp)
-            self.extension_manager.homescreen_manager.set_mycroft_ready(resp)
-
         self.status.set_ready()
         LOG.info(f"GUI Service Ready")
 

--- a/test/unittests/test_homescreen.py
+++ b/test/unittests/test_homescreen.py
@@ -13,7 +13,6 @@ class TestHomescreenManager(unittest.TestCase):
 
     def test_00_homescreen_manager_init(self):
         self.assertEqual(self.homescreen_manager.bus, self.bus)
-        self.assertFalse(self.homescreen_manager.mycroft_ready)
         self.assertIsInstance(self.homescreen_manager.homescreens, list)
         # TODO: Test messagebus handlers
 
@@ -71,8 +70,3 @@ class TestHomescreenManager(unittest.TestCase):
     def test_show_homescreen(self):
         # TODO
         pass
-
-    def test_set_mycroft_ready(self):
-        self.homescreen_manager.mycroft_ready = False
-        self.homescreen_manager.set_mycroft_ready(Message("mycroft.ready"))
-        self.assertTrue(self.homescreen_manager.mycroft_ready)

--- a/test/unittests/test_namespace.py
+++ b/test/unittests/test_namespace.py
@@ -221,15 +221,6 @@ class TestNamespaceManager(TestCase):
         # TODO
         pass
 
-    def test_handle_ready(self):
-        self.assertEqual(len(self.namespace_manager.core_bus.ee.
-                             listeners("gui.volunteer_page_upload")), 0)
-        self.assertFalse(self.namespace_manager._ready_event.is_set())
-        self.namespace_manager.handle_ready(Message(""))
-        self.assertTrue(self.namespace_manager._ready_event.wait(0.01))
-        self.assertEqual(len(self.namespace_manager.core_bus.ee.
-                             listeners("gui.volunteer_page_upload")), 1)
-
     def test_handle_gui_pages_available(self):
         # TODO
         pass


### PR DESCRIPTION
dont wait for mycroft.ready message, display homescreen ASAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified homescreen display logic, allowing the homescreen to show immediately upon initialization without waiting for Mycroft readiness.
  
- **Bug Fixes**
	- Removed outdated checks related to Mycroft's readiness state, streamlining the homescreen management process.

- **Tests**
	- Updated unit tests by removing tests related to the Mycroft readiness state, reflecting the changes in homescreen logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->