### PR TITLE
feat: forward some events to GUI clients

### DIFF
--- a/ovos_gui/namespace.py
+++ b/ovos_gui/namespace.py
@@ -459,47 +459,50 @@ class NamespaceManager:
         self._define_messages_to_forward()
 
     def _define_messages_to_forward(self):
-        """messages from regular bus that should be wrapped under GUI protocol and sent to GUI clients"""
-        # Audio Service
-        self.core_bus.on("recognizer_loop:audio_output_start", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:audio_output_end", self.forward_to_gui)
-        # Speech Service
-        self.core_bus.on("recognizer_loop:sleep", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:wake_up", self.forward_to_gui)
-        self.core_bus.on("mycroft.awoken", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:wakeword", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:recognition_unknown", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:record_begin", self.forward_to_gui)
-        self.core_bus.on("recognizer_loop:record_end", self.forward_to_gui)
-        # enclosure commands for eyes
-        self.core_bus.on('enclosure.eyes.on', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.off', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.blink', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.narrow', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.look', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.color', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.level', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.volume', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.spin', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.timedspin', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.reset', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.setpixel', self.forward_to_gui)
-        self.core_bus.on('enclosure.eyes.fill', self.forward_to_gui)
-        # enclosure commands for mouth
-        self.core_bus.on("enclosure.mouth.events.activate", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.events.deactivate", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.talk", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.think", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.listen", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.smile", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.viseme", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.viseme_list", self.forward_to_gui)
-        # mouth/matrix display
-        self.core_bus.on("enclosure.mouth.reset", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.text", self.forward_to_gui)
-        self.core_bus.on("enclosure.mouth.display", self.forward_to_gui)
-        self.core_bus.on("enclosure.weather.display", self.forward_to_gui)
-
+        """Messages from the core bus to be forwarded to GUI clients."""
+        messages_to_forward = [
+            # Audio Service
+            "recognizer_loop:audio_output_start",
+            "recognizer_loop:audio_output_end",
+            # Speech Service
+            "recognizer_loop:sleep",
+            "recognizer_loop:wake_up",
+            "mycroft.awoken",
+            "recognizer_loop:wakeword",
+            "recognizer_loop:recognition_unknown",
+            "recognizer_loop:record_begin",
+            "recognizer_loop:record_end",
+            # Enclosure commands for eyes
+            "enclosure.eyes.on",
+            "enclosure.eyes.off",
+            "enclosure.eyes.blink",
+            "enclosure.eyes.narrow",
+            "enclosure.eyes.look",
+            "enclosure.eyes.color",
+            "enclosure.eyes.level",
+            "enclosure.eyes.volume",
+            "enclosure.eyes.spin",
+            "enclosure.eyes.timedspin",
+            "enclosure.eyes.reset",
+            "enclosure.eyes.setpixel",
+            "enclosure.eyes.fill",
+            # Enclosure commands for mouth
+            "enclosure.mouth.events.activate",
+            "enclosure.mouth.events.deactivate",
+            "enclosure.mouth.talk",
+            "enclosure.mouth.think",
+            "enclosure.mouth.listen",
+            "enclosure.mouth.smile",
+            "enclosure.mouth.viseme",
+            "enclosure.mouth.viseme_list",
+            # Mouth/matrix display
+            "enclosure.mouth.reset",
+            "enclosure.mouth.text",
+            "enclosure.mouth.display",
+            "enclosure.weather.display"
+        ]
+        for msg in messages_to_forward:
+            self.core_bus.on(msg, self.forward_to_gui)
     @staticmethod
     def forward_to_gui(message: Message):
         """

--- a/ovos_gui/namespace.py
+++ b/ovos_gui/namespace.py
@@ -503,6 +503,7 @@ class NamespaceManager:
         ]
         for msg in messages_to_forward:
             self.core_bus.on(msg, self.forward_to_gui)
+
     @staticmethod
     def forward_to_gui(message: Message):
         """

--- a/test/unittests/test_extensions.py
+++ b/test/unittests/test_extensions.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, Mock
 
 import ovos_gui.extensions
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_gui.homescreen import HomescreenManager
 from ovos_gui.extensions import ExtensionsManager
 from .mocks import base_config

--- a/test/unittests/test_homescreen.py
+++ b/test/unittests/test_homescreen.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from ovos_bus_client.message import Message
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_gui.namespace import NamespaceManager
 
 

--- a/test/unittests/test_namespace.py
+++ b/test/unittests/test_namespace.py
@@ -19,7 +19,7 @@ from unittest import TestCase, mock
 from unittest.mock import Mock
 
 from ovos_bus_client.message import Message
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 
 from ovos_gui.constants import GUI_CACHE_PATH
 from ovos_gui.namespace import Namespace


### PR DESCRIPTION
allow GUIs to react to wakeword etc without needing a connection to the main bus

GUI clients are not supposed to connect to the main bus, only to the GUI bus, but in practice the QT gui has been connecting to both due to missing events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced namespace management for improved audio and visual interactions in the GUI.
	- Introduced a new method for forwarding messages related to system events.

- **Bug Fixes**
	- Improved error handling and logging for namespace operations.

- **Chores**
	- Updated import paths for `FakeBus` across multiple test files to reflect module reorganization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->