### PR TITLE
refactor: migrate packaging to pyproject.toml

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,108 +1,22 @@
 name: Release Alpha and Propose Stable
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [dev]
 
 jobs:
   publish_alpha:
-    if: github.event.pull_request.merged == true
-    uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: OpenVoiceOS/gh-automations/.github/workflows/publish-alpha.yml@dev
     secrets: inherit
     with:
       branch: 'dev'
       version_file: 'ovos_gui/version.py'
-      setup_py: 'setup.py'
       update_changelog: true
       publish_prerelease: true
+      propose_release: true
       changelog_max_issues: 100
-
-  notify:
-    if: github.event.pull_request.merged == true
-    needs: publish_alpha
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Send message to Matrix bots channel
-        id: matrix-chat-message
-        uses: fadenb/matrix-chat-message@v0.0.6
-        with:
-          homeserver: 'matrix.org'
-          token: ${{ secrets.MATRIX_TOKEN }}
-          channel: '!WjxEKjjINpyBRPFgxl:krbel.duckdns.org'
-          message: |
-            new ${{ github.event.repository.name }} PR merged! https://github.com/${{ github.repository }}/pull/${{ github.event.number }}
-
-  publish_pypi:
-    needs: publish_alpha
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: dev
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - name: Install Build Tools
-        run: |
-          python -m pip install build wheel
-      - name: version
-        run: echo "::set-output name=version::$(python setup.py --version)"
-        id: version
-      - name: Build Distribution Packages
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{secrets.PYPI_TOKEN}}
-
-
-  propose_release:
-    needs: publish_alpha
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout dev branch
-        uses: actions/checkout@v4
-        with:
-          ref: dev
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Get version from setup.py
-        id: get_version
-        run: |
-          VERSION=$(python setup.py --version)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create and push new branch
-        run: |
-          git checkout -b release-${{ env.VERSION }}
-          git push origin release-${{ env.VERSION }}
-
-      - name: Open Pull Request from dev to master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Variables
-          BRANCH_NAME="release-${{ env.VERSION }}"
-          BASE_BRANCH="master"
-          HEAD_BRANCH="release-${{ env.VERSION }}"
-          PR_TITLE="Release ${{ env.VERSION }}"
-          PR_BODY="Human review requested!"
-
-          # Create a PR using GitHub API
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$HEAD_BRANCH\",\"base\":\"$BASE_BRANCH\"}" \
-            https://api.github.com/repos/${{ github.repository }}/pulls
-
+      publish_pypi: true
+      notify_matrix: true


### PR DESCRIPTION
Migrate packaging to **pyproject.toml** (PEP 621) and drop `setup.py`, `requirements*.txt`, and `MANIFEST.in`.

This also fixes the broken alpha release that kept merged dep-cap fixes (e.g. `ovos-bus-client<3.0.0`) from publishing: the old workflow used `TigreGotico/...publish-alpha.yml@master` with an inline `python setup.py sdist bdist_wheel` that failed on the py3.14 runner (`ModuleNotFoundError: setuptools`). Now uses the standard `OpenVoiceOS/...publish-alpha.yml@dev` + `python -m build`.

Verified locally: `uv build --wheel` succeeds, console scripts and bundled `res/` resources are present, version resolves dynamically from `version.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)