### PR TITLE
fix: drop archived shell-companion extra + single-source deps in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,6 @@ dependencies = [
     "ovos-plugin-manager>=0.5.5,<3.0.0",
 ]
 
-[project.optional-dependencies]
-extras = ["ovos-gui-plugin-shell-companion>=1.0.1,<2.0.0"]
-
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-gui"
 


### PR DESCRIPTION
`ovos-gui-plugin-shell-companion` is archived and pins `ovos-bus-client<2.0`, blocking the bus-client 2.x adoption for any consumer of `ovos-gui[extras]` (e.g. `ovos-core[mycroft]`). It was the sole member of the `extras` optional-dependency and has no successor, so the extra is removed.

Also drops the vestigial `requirements/*.txt` (duplicated the pyproject `[project].dependencies`; `dynamic` only sets version).

gui's own deps already allow bus-client 2.x (`<3.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)