### PR TITLE
fix: lift ovos-spec-tools upper bound (spec-tools 1.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "ovos_bus_client>=2.2.0a1,<3.0.0",
-    "ovos-spec-tools>=0.9.0a1,<1.0.0",
+    "ovos-spec-tools>=0.9.0a1",
     "ovos-utils>=0.0.37,<1.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "tornado~=6.0, >=6.0.3",


### PR DESCRIPTION
spec-tools crossed to 1.x (1.1.0a1 published) — PR #63 (`fix!`) dropped the handler-trio entries from the namespace migration bridge. Consumers capping `ovos-spec-tools<1.0.0` can no longer resolve against the current stack (e.g. ovos-bus-client 2.6.0a1 requires `ovos-spec-tools>=1.1.0a1`).

This drops the upper bound entirely (keeps the floor) so the stack resolves. Verified: with the uncapped floor, uv resolves `ovos-spec-tools==1.1.0a1` alongside `ovos-bus-client==2.6.0a1` with no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to allow newer compatible versions, improving flexibility for future installs and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->